### PR TITLE
Add /beta demo page (nextstepjs 2.3.0-beta.0)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "motion": "^11.15.0",
         "next": "^16.2.1",
         "next-sitemap": "^4.2.3",
-        "nextstepjs": "^2.2.0",
+        "nextstepjs": "^2.3.0-beta.0",
         "prismjs": "^1.29.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -816,7 +816,7 @@
 
     "next-sitemap": ["next-sitemap@4.2.3", "", { "dependencies": { "@corex/deepmerge": "^4.0.43", "@next/env": "^13.4.3", "fast-glob": "^3.2.12", "minimist": "^1.2.8" }, "peerDependencies": { "next": "*" }, "bin": { "next-sitemap": "bin/next-sitemap.mjs", "next-sitemap-cjs": "bin/next-sitemap.cjs" } }, "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ=="],
 
-    "nextstepjs": ["nextstepjs@2.2.0", "", { "peerDependencies": { "@remix-run/react": ">=1.0.0", "motion": ">=11", "next": ">=13.0.0", "react": ">=18", "react-dom": ">=18", "react-router": ">=7.0.0" }, "optionalPeers": ["@remix-run/react", "next", "react-router"] }, "sha512-VpUvKpIMbxBaLAMM3O8mc5Tavao4UBpKZ0+KyUGXxZhqdJt2ejS2l7pXLtlq2r62NG3EV0yv1wit5mgte7c3Vw=="],
+    "nextstepjs": ["nextstepjs@2.3.0-beta.0", "", { "peerDependencies": { "@remix-run/react": ">=1.0.0", "motion": ">=11", "next": ">=13.0.0", "react": ">=18", "react-dom": ">=18", "react-router": ">=7.0.0" }, "optionalPeers": ["@remix-run/react", "next", "react-router"] }, "sha512-/M1D1BByeX0LsjQE4xrLj9BhxlFtSkn5/li/LOmgx68hazi8uvdwhqvwJksdNMD2GdbJuD/ulRllBn0dIUbDgw=="],
 
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -6,6 +6,8 @@ module.exports = {
   generateIndexSitemap: true,
   changefreq: 'weekly',
   priority: 0.7,
+  // Keep the beta demo/E2E route out of the sitemap.
+  exclude: ['/beta', '/beta/*'],
   // Set higher priority for homepage and important pages
   transform: async (config, path) => {
     // Homepage gets highest priority
@@ -51,6 +53,7 @@ module.exports = {
       {
         userAgent: '*',
         allow: '/',
+        disallow: ['/beta'],
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "motion": "^11.15.0",
     "next": "^16.2.1",
     "next-sitemap": "^4.2.3",
-    "nextstepjs": "^2.2.0",
+    "nextstepjs": "^2.3.0-beta.0",
     "prismjs": "^1.29.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,7 @@
 # *
 User-agent: *
 Allow: /
+Disallow: /beta
 
 # Host
 Host: https://nextstepjs.com

--- a/src/app/beta/page.tsx
+++ b/src/app/beta/page.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useState, type CSSProperties } from 'react';
+import {
+  NextStepProvider,
+  NextStepReact,
+  useNextStep,
+  type Tour,
+} from 'nextstepjs';
+
+/**
+ * Isolated test page for the beta improvements (cardOffset, scrollOffset, selector
+ * retry, side-swap room check, anchor-centered caret, arrowStyle). It mounts its
+ * OWN NextStepProvider + NextStepReact so it never touches the live site's tours.
+ * Inline styles keep it self-contained and responsive for the mobile E2E project.
+ *
+ * Mirrored by nextstepjs-remix/app/routes/beta.tsx and driven by e2e/shared/beta.ts.
+ */
+
+const ARROW_COLOR = 'rgb(255, 0, 64)';
+
+const target: CSSProperties = {
+  background: '#2563eb',
+  color: '#fff',
+  borderRadius: 8,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: 12,
+  fontWeight: 600,
+};
+
+const betaSteps: Tour[] = [
+  {
+    tour: 'beta',
+    steps: [
+      {
+        title: 'Card offset',
+        content: <p>A larger gap between the card and the spotlight.</p>,
+        selector: '#beta-offset-target',
+        side: 'bottom',
+        cardOffset: 100,
+        showControls: true,
+        showSkip: true,
+        pointerPadding: 10,
+        pointerRadius: 8,
+      },
+      {
+        title: 'Caret tracks anchor',
+        content: <p>The caret points at the element center, not the card center.</p>,
+        selector: '#beta-caret-target',
+        side: 'bottom-right',
+        showControls: true,
+        showSkip: true,
+        pointerPadding: 12,
+        pointerRadius: 8,
+      },
+      {
+        title: 'Scroll offset',
+        content: <p>The target is kept clear of the fixed header.</p>,
+        selector: '#beta-scroll-target',
+        side: 'bottom',
+        scrollOffset: 120,
+        showControls: true,
+        showSkip: true,
+        pointerPadding: 10,
+        pointerRadius: 8,
+      },
+      {
+        title: 'Side with room',
+        content: <p>A near-top target flips below where there is room.</p>,
+        selector: '#beta-b3-target',
+        side: 'top',
+        showControls: true,
+        showSkip: true,
+        pointerPadding: 10,
+        pointerRadius: 8,
+      },
+      {
+        title: 'Async target',
+        content: <p>This element renders late and is found via retry.</p>,
+        selector: '#beta-async-target',
+        side: 'bottom',
+        selectorRetryAttempts: 20,
+        selectorRetryDelay: 150,
+        showControls: true,
+        showSkip: true,
+        pointerPadding: 10,
+        pointerRadius: 8,
+      },
+    ],
+  },
+];
+
+function BetaContent({ asyncMounted }: { asyncMounted: boolean }) {
+  const { startNextStep } = useNextStep();
+
+  return (
+    <>
+      {/* Fixed header to validate scrollOffset (B2). */}
+      <div
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 80,
+          background: '#111827',
+          color: '#fff',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 50,
+        }}
+      >
+        Fixed header (80px)
+      </div>
+
+      <div style={{ paddingTop: 100, paddingBottom: 200, minHeight: 3000 }}>
+        <div style={{ textAlign: 'center' }}>
+          <h1 style={{ fontSize: 24, fontWeight: 700 }}>NextStep beta features</h1>
+          <button
+            type="button"
+            onClick={() => startNextStep('beta')}
+            style={{
+              marginTop: 12,
+              padding: '8px 16px',
+              borderRadius: 6,
+              background: '#2563eb',
+              color: '#fff',
+              cursor: 'pointer',
+            }}
+          >
+            Start Beta Tour
+          </button>
+        </div>
+
+        {/* Near-top target for the side-room check (B3). */}
+        <div
+          id="beta-b3-target"
+          style={{ ...target, position: 'absolute', top: 110, left: 16, width: 80, height: 40 }}
+        >
+          B3
+        </div>
+
+        <div
+          id="beta-offset-target"
+          style={{ ...target, position: 'absolute', top: 260, left: 24, width: 90, height: 48 }}
+        >
+          Offset
+        </div>
+
+        <div
+          id="beta-caret-target"
+          style={{
+            ...target,
+            position: 'absolute',
+            top: 460,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: 120,
+            height: 48,
+          }}
+        >
+          Caret
+        </div>
+
+        {asyncMounted && (
+          <div
+            id="beta-async-target"
+            style={{ ...target, position: 'absolute', top: 700, left: 24, width: 100, height: 48 }}
+          >
+            Async
+          </div>
+        )}
+
+        <div
+          id="beta-scroll-target"
+          style={{ ...target, position: 'absolute', top: 1900, left: 24, width: 120, height: 48 }}
+        >
+          Scroll
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default function BetaPage() {
+  const [asyncMounted, setAsyncMounted] = useState(false);
+
+  return (
+    <NextStepProvider>
+      <NextStepReact
+        steps={betaSteps}
+        arrowStyle={{ color: ARROW_COLOR }}
+        scrollToTop={false}
+        onStepChange={(step) => {
+          // Mount the async target shortly after reaching its step (index 4).
+          if (step === 4) {
+            setAsyncMounted(false);
+            setTimeout(() => setAsyncMounted(true), 600);
+          }
+        }}
+      >
+        <BetaContent asyncMounted={asyncMounted} />
+      </NextStepReact>
+    </NextStepProvider>
+  );
+}


### PR DESCRIPTION
## Summary
Adds an isolated `/beta` page that demos and E2E-exercises the `nextstepjs@2.3.0-beta.0` features: `cardOffset`, `scrollOffset`, selector retry, side-swap room check, anchor-centered caret, and `arrowStyle`. It mounts its own `NextStepProvider`, so it never touches the live site's tours.

- Bumps `nextstepjs` to `^2.3.0-beta.0` (the page uses beta-only APIs).
- Excludes `/beta` from the sitemap (`next-sitemap.config.js`) and adds `Disallow: /beta` to `robots.txt`.

## Merge order (important)
Merge **after** `nextstepjs@2.3.0-beta.0` is published to npm. Until then the dependency cannot resolve, so the build/preview will fail (expected). After publishing, run `bun install` to refresh the lockfile.